### PR TITLE
INFRA-555 Fix deprecated functionalities

### DIFF
--- a/.github/workflows/api-base-build-image.yml
+++ b/.github/workflows/api-base-build-image.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
      
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: AKIASEZWNC2I2O2VVBFY
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -86,7 +86,8 @@ jobs:
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
+          echo "k8sVersion=${k8sVersion:=${{ env.WP_K8S_VERSION }}}" >> $GITHUB_OUTPUT
+          # echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
           
       - name: Clone workpath_k8s repository
         uses: actions/checkout@v3

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.WP_ENVIRONMENT }}
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/prologue.yml
+++ b/.github/workflows/prologue.yml
@@ -66,12 +66,5 @@ jobs:
           echo "git_short_sha=$GIT_SHORT_SHA" >> $GITHUB_OUTPUT
           echo "wp_subdomain=$WP_SUBDOMAIN" >> $GITHUB_OUTPUT
           echo "git_commit_author_subject=$GIT_COMMIT_AUTHOR_SUBJECT" >> $GITHUB_OUTPUT
-          # echo "::set-output name=git_project_name::$GIT_PROJECT_NAME"
-          # echo "::set-output name=git_branch::$GIT_BRANCH"
-          # echo "::set-output name=git_shortened_branch::$GIT_SHORTENED_BRANCH"
-          # echo "::set-output name=git_sha::$GIT_SHA"
-          # echo "::set-output name=git_short_sha::$GIT_SHORT_SHA"
-          # echo "::set-output name=wp_subdomain::$WP_SUBDOMAIN"
-          # echo "::set-output name=git_commit_author_subject::$GIT_COMMIT_AUTHOR_SUBJECT"
           
       

--- a/.github/workflows/prologue.yml
+++ b/.github/workflows/prologue.yml
@@ -59,11 +59,19 @@ jobs:
           GIT_SHORT_SHA=$(echo $GIT_SHA | cut -c1-7)
           WP_SUBDOMAIN="$GIT_SHORTENED_BRANCH-$GIT_SHORT_SHA"
           GIT_COMMIT_AUTHOR_SUBJECT=$(git show -s --format='%an %s')
-          echo "::set-output name=git_project_name::$GIT_PROJECT_NAME"
-          echo "::set-output name=git_branch::$GIT_BRANCH"
-          echo "::set-output name=git_shortened_branch::$GIT_SHORTENED_BRANCH"
-          echo "::set-output name=git_sha::$GIT_SHA"
-          echo "::set-output name=git_short_sha::$GIT_SHORT_SHA"
-          echo "::set-output name=wp_subdomain::$WP_SUBDOMAIN"
-          echo "::set-output name=git_commit_author_subject::$GIT_COMMIT_AUTHOR_SUBJECT"
+          echo "git_project_name=$GIT_PROJECT_NAME" >> $GITHUB_OUTPUT
+          echo "git_branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
+          echo "git_shortened_branch=$GIT_SHORTENED_BRANCH" >> $GITHUB_OUTPUT
+          echo "git_sha=$GIT_SHA" >> $GITHUB_OUTPUT
+          echo "git_short_sha=$GIT_SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "wp_subdomain=$WP_SUBDOMAIN" >> $GITHUB_OUTPUT
+          echo "git_commit_author_subject=$GIT_COMMIT_AUTHOR_SUBJECT" >> $GITHUB_OUTPUT
+          # echo "::set-output name=git_project_name::$GIT_PROJECT_NAME"
+          # echo "::set-output name=git_branch::$GIT_BRANCH"
+          # echo "::set-output name=git_shortened_branch::$GIT_SHORTENED_BRANCH"
+          # echo "::set-output name=git_sha::$GIT_SHA"
+          # echo "::set-output name=git_short_sha::$GIT_SHORT_SHA"
+          # echo "::set-output name=wp_subdomain::$WP_SUBDOMAIN"
+          # echo "::set-output name=git_commit_author_subject::$GIT_COMMIT_AUTHOR_SUBJECT"
+          
       

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -38,6 +38,7 @@ jobs:
           repository: WorkpathHQ/github_action_cicd
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           path: ${{ github.workspace }}/github_action_cicd
+          ref: INFRA-555-fix-deprecated-functionalities
 
       - name: readJson
         id: readJson

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -65,8 +65,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-         
-          echo "::set-output name=packageJson::$content"
+          echo "packageJson=$content" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
         run: | 

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -38,7 +38,6 @@ jobs:
           repository: WorkpathHQ/github_action_cicd
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           path: ${{ github.workspace }}/github_action_cicd
-          ref: INFRA-555-fix-deprecated-functionalities
 
       - name: readJson
         id: readJson

--- a/.github/workflows/web-base-build-image.yml
+++ b/.github/workflows/web-base-build-image.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
      
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -81,7 +81,8 @@ jobs:
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
+          echo "k8sVersion=${k8sVersion:=${{ env.WP_K8S_VERSION }}}" >> $GITHUB_OUTPUT
+          # echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
 
       - name: Clone workpath_k8s repository
         uses: actions/checkout@v3

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.WP_ENVIRONMENT }}
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -1,0 +1,16 @@
+{
+    "attachments": [{
+      "color": "#f75819",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "
+            *'$GIT_PROJECT_NAME'*\n
+            $GIT_TRIGGERING_ACTOR's deployment failed - <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n"
+          }
+        }
+      ]
+    }]
+  }

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -1,19 +1,19 @@
 {
-"attachments": [
-    {
-        "color": "#f75819",
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": " 
+    "attachments": [
+        {
+            "color": "#f75819",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": " 
                     *'$GIT_PROJECT_NAME'*\n
                     $GIT_TRIGGERING_ACTOR's deployment failed!\n
                     <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
+                    }
                 }
-            }
-        ]
-    }
-]
+            ]
+        }
+    ]
 }

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -1,16 +1,19 @@
 {
-    "attachments": [{
-      "color": "#f75819",
-      "blocks": [
-        {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "
-            *'$GIT_PROJECT_NAME'*\n
-            $GIT_TRIGGERING_ACTOR's deployment failed - <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n"
-          }
-        }
-      ]
-    }]
-  }
+"attachments": [
+    {
+        "color": "#f75819",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": " 
+                    *'$GIT_PROJECT_NAME'*\n
+                    $GIT_TRIGGERING_ACTOR's deployment failed!\n
+                    <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
+                }
+            }
+        ]
+    }
+]
+}

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -9,8 +9,8 @@
                         "type": "mrkdwn",
                         "text": " 
                     *'$GIT_PROJECT_NAME'*\n
-                    $GIT_TRIGGERING_ACTOR's deployment failed!\n
-                    <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
+                    <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | new stack> created by $GIT_TRIGGERING_ACTOR\n
+                    $GIT_TRIGGERING_ACTOR's deployment failed!"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -9,8 +9,8 @@
                         "type": "mrkdwn",
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
-                        $GIT_TRIGGERING_ACTOR\'s <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA>"
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -10,7 +10,7 @@
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
                         $GIT_TRIGGERING_ACTOR's deployment failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA>"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -10,7 +10,8 @@
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
                         $GIT_TRIGGERING_ACTOR's deployment failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> "
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> 
+                        test"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -10,7 +10,7 @@
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
                         $GIT_TRIGGERING_ACTOR\'s <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA>"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -10,7 +10,7 @@
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
                         $GIT_TRIGGERING_ACTOR's deployment failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA>"
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> "
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -1,16 +1,16 @@
 {
     "attachments": [
         {
-            "color": "#f75819",
+            "color": "#f2c744",
             "blocks": [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": " 
-                    *'$GIT_PROJECT_NAME'*\n
-                    <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | new stack> created by $GIT_TRIGGERING_ACTOR\n
-                    $GIT_TRIGGERING_ACTOR's deployment failed!"
+                        *'$GIT_PROJECT_NAME'*\n
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
                     }
                 }
             ]

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -1,7 +1,7 @@
 {
     "attachments": [
         {
-            "color": "#f2c744",
+            "color": "#f75819",
             "blocks": [
                 {
                     "type": "section",
@@ -9,7 +9,7 @@
                         "type": "mrkdwn",
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
+                        $GIT_TRIGGERING_ACTOR's deployment failed\n
                         <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
                     }
                 }

--- a/payloads/failed_payload.json
+++ b/payloads/failed_payload.json
@@ -9,9 +9,8 @@
                         "type": "mrkdwn",
                         "text": " 
                         *'$GIT_PROJECT_NAME'*\n
-                        $GIT_TRIGGERING_ACTOR's deployment failed\n
-                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> 
-                        test"
+                        $GIT_TRIGGERING_ACTOR\'s <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | deployment> by $GIT_TRIGGERING_ACTOR failed\n
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT"
                     }
                 }
             ]

--- a/payloads/production_predeploy_payload.json
+++ b/payloads/production_predeploy_payload.json
@@ -1,0 +1,18 @@
+{
+    "attachments": [{
+      "color": "#04c09c",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "
+            *'$GIT_PROJECT_NAME'*\n
+            ⏲️ deployment of new  <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | release> started by $GIT_TRIGGERING_ACTOR\n
+            <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n
+            <https://workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-production%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
+          }
+        }
+      ]
+    }]
+  }

--- a/payloads/staging_predeployment_payload.json
+++ b/payloads/staging_predeployment_payload.json
@@ -11,7 +11,7 @@
                         *'$GIT_PROJECT_NAME'*\n
                         ⏲️ deployment of new <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | release> started by $GIT_TRIGGERING_ACTOR\n
                         <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n
-                        <https: //workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-staging%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
+                        <https://workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-staging%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
                     }
                 }
             ]

--- a/payloads/staging_predeployment_payload.json
+++ b/payloads/staging_predeployment_payload.json
@@ -1,0 +1,17 @@
+{
+    "attachments": [{
+        "color": "#f2c744",
+        "blocks": [{
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": "
+            *'$GIT_PROJECT_NAME'*\n
+            ⏲️ deployment of new <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | release> started by $GIT_TRIGGERING_ACTOR\n
+            <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n
+            <https://workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-staging%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
+
+        }
+        }]
+    }]
+  }

--- a/payloads/staging_predeployment_payload.json
+++ b/payloads/staging_predeployment_payload.json
@@ -1,17 +1,20 @@
 {
-    "attachments": [{
-        "color": "#f2c744",
-        "blocks": [{
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "
-            *'$GIT_PROJECT_NAME'*\n
-            ⏲️ deployment of new <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | release> started by $GIT_TRIGGERING_ACTOR\n
-            <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n
-            <https://workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-staging%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
-
+    "attachments": [
+        {
+            "color": "#f2c744",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": " 
+                        *'$GIT_PROJECT_NAME'*\n
+                        ⏲️ deployment of new <$GIT_SERVER_URL/$GIT_REPOSITORY/actions/runs/$GIT_RUN_ID | release> started by $GIT_TRIGGERING_ACTOR\n
+                        <$GIT_SERVER_URL/$GIT_REPOSITORY/commit/$GIT_SHA | $GIT_SHORT_SHA> | $GIT_COMMIT_AUTHOR_SUBJECT\n
+                        <https: //workpath.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-workpath-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22workpath-staging%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D|Grafana> | Application Logs"
+                    }
+                }
+            ]
         }
-        }]
-    }]
-  }
+    ]
+}


### PR DESCRIPTION
# (Implements | Fixes ) [INFRA-555](https://workpathhq.atlassian.net/browse/INFRA-555) and [INFRA-558](https://workpathhq.atlassian.net/browse/INFRA-558)


<!--- The purpose of creating a good PR is to present your work to the reviewer, so that it's easy to understand the task and its implementation. This also serves as our own documentation for each line of code we touch ✨ -->

## Summary ⚡️
This PR fixes the deprecation warnings regarding the usage of Node12 in the AWS Action modules and replaces the old ::set-output commands with the new GITHUB_ENV commands to fix deprecation warnings.

Slack messages for failing pipelines and predeployment messages were added to staging and production deployments.
<!--- Brief description (can be a single sentence) of what this PR does. Basically a TLDR; -->
<!--- For example: This PR fixes the issue where... This PR implements... -->

## Details 🕵️‍♀️
There were updates deprecating the usage of Node12 and save-state and set-output commands. 
Actions will begin running on Node 16 in the future.

Example for failing deployment: https://workpath.slack.com/archives/C039D0B85U0/p1666974219967759

Example for predeployment message: https://workpath.slack.com/archives/C039D0B85U0/p1666972584106989

For more information check the following links:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

API PR:
WEB PR: