### PR TITLE
[INFRA-578] Using latest for k8s

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+# Fixes [PLAT-123](https://workpathhq.atlassian.net/browse/PLAT-123)
+
+## Summary
+
+## Details
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Fixes [PLAT-123](https://workpathhq.atlassian.net/browse/PLAT-123)
+# Fixes [JIRA_ID](https://workpathhq.atlassian.net/browse/JIRA_ID)
 
 ## Summary
 

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -62,7 +62,7 @@ on:
         required: true
 
 env:
-  WP_K8S_VERSION: v0.4.14
+  WP_K8S_VERSION: latest
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -57,7 +57,7 @@ on:
 
 
 env: 
-  WP_K8S_VERSION: v0.4.14
+  WP_K8S_VERSION: latest
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:     


### PR DESCRIPTION
# Fixes [PLAT-578](https://workpathhq.atlassian.net/browse/578)

## Summary
- added PR template
- referencing to latest in CD

## Details
Since we can optionally set the latest tag to new releases in the workpath_k8s repository and optionally provide a version with the WP_K8S_VERSION, we decided to use the latest tag now.
With this option we don't need to update the version to the latest version in this repository, each time a new release is created.

[Confluence Page](https://workpathhq.atlassian.net/wiki/spaces/OP/pages/6843760797/Release+management+of+workpath+k8s) about the release management.

