### PR TITLE
INFRA-578 CD: Using latest for workpath_ k8s

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+# Fixes [PLAT-123](https://workpathhq.atlassian.net/browse/PLAT-123)
+
+## Summary
+
+## Details
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Fixes [PLAT-123](https://workpathhq.atlassian.net/browse/PLAT-123)
+# Fixes [JIRA_ID](https://workpathhq.atlassian.net/browse/JIRA_ID)
 
 ## Summary
 

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -62,7 +62,7 @@ on:
         required: true
 
 env:
-  WP_K8S_VERSION: v0.4.14
+  WP_K8S_VERSION: latest
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -87,14 +87,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
-      - run: latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+      - id: latest_release_tag
+        run: latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "latest_release_tag=$latestReleaseTag" >> $GITHUB_OUTPUT
 
       - name: Replace k8s Version when provided
         # Added so a k8s version can be optionally chosen. If no k8s version is provided in the inputs, uses the version in env.
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "k8sVersion=${k8sVersion:=$latestReleaseTag}" >> $GITHUB_OUTPUT
+          echo "k8sVersion=${k8sVersion:=${{ jobs.latest_release_tag.outputs.latest_release_tag }}}" >> $GITHUB_OUTPUT
         
 
       - name: Clone workpath_k8s repository

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -96,7 +96,7 @@ jobs:
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "k8sVersion=${k8sVersion:=${{ jobs.latest_release_tag.outputs.latest_release_tag }}}" >> $GITHUB_OUTPUT
+          echo "k8sVersion=${k8sVersion:=${{ steps.latest_release_tag.outputs.latest_release_tag }}}" >> $GITHUB_OUTPUT
         
 
       - name: Clone workpath_k8s repository

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -96,7 +96,7 @@ jobs:
           ref: ${{ steps.k8sVersion.outputs.k8sVersion }}
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           path: ${{ github.workspace }}/workpath_k8s
-          fetch-dept: 0
+          fetch-depth: 0
 
       - name: Deploying
         # Added if else to differentiate between the environments

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -62,7 +62,7 @@ on:
         required: true
 
 env:
-  WP_K8S_VERSION: latest
+  WP_K8S_VERSION: 'latest'
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:
@@ -87,7 +87,7 @@ jobs:
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
           echo "k8sVersion=${k8sVersion:=${{ env.WP_K8S_VERSION }}}" >> $GITHUB_OUTPUT
-          # echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
+        
 
       - name: Clone workpath_k8s repository
         uses: actions/checkout@v3
@@ -96,6 +96,7 @@ jobs:
           ref: ${{ steps.k8sVersion.outputs.k8sVersion }}
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           path: ${{ github.workspace }}/workpath_k8s
+          fetch-dept: 0
 
       - name: Deploying
         # Added if else to differentiate between the environments

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -101,7 +101,6 @@ jobs:
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
           echo "k8sVersion=${k8sVersion:=${{ steps.latest_release_tag.outputs.latest_release_tag }}}" >> $GITHUB_OUTPUT
         
-
       - name: Clone workpath_k8s repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -88,8 +88,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - id: latest_release_tag
-        run: latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+        run: |
+          latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
           echo "latest_release_tag=$latestReleaseTag" >> $GITHUB_OUTPUT
+        env:
+          RESULT: ${{ steps.get_latest_release.outputs.data }}
 
       - name: Replace k8s Version when provided
         # Added so a k8s version can be optionally chosen. If no k8s version is provided in the inputs, uses the version in env.

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -62,7 +62,6 @@ on:
         required: true
 
 env:
-  WP_K8S_VERSION: 'latest'
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:
@@ -81,12 +80,21 @@ jobs:
         run: |
           aws eks --region ${{ env.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ inputs.EKS_CLUSTER }}
 
+      - uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/WorkpathHQ/workpath_k8s/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+      - run: latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
       - name: Replace k8s Version when provided
         # Added so a k8s version can be optionally chosen. If no k8s version is provided in the inputs, uses the version in env.
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "k8sVersion=${k8sVersion:=${{ env.WP_K8S_VERSION }}}" >> $GITHUB_OUTPUT
+          echo "k8sVersion=${k8sVersion:=$latestReleaseTag}" >> $GITHUB_OUTPUT
         
 
       - name: Clone workpath_k8s repository

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -57,7 +57,7 @@ on:
 
 
 env: 
-  WP_K8S_VERSION: v0.4.14
+  WP_K8S_VERSION: latest
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:     

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -75,13 +75,26 @@ jobs:
         run: |
           aws eks --region ${{ env.AWS_DEFAULT_REGION }} update-kubeconfig --name ${{ inputs.EKS_CLUSTER }}
           
+      - uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/WorkpathHQ/workpath_k8s/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+
+      - id: latest_release_tag
+        run: |
+          latestReleaseTag=$(echo $RESULT | jq | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "latest_release_tag=$latestReleaseTag" >> $GITHUB_OUTPUT
+        env:
+          RESULT: ${{ steps.get_latest_release.outputs.data }}
+
       - name: Replace k8s Version when provided
         # Added so a k8s version can be optionally chosen. If no k8s version is provided in the inputs, uses the version in env.
         id: k8sVersion
         run: |
           k8sVersion=${{ inputs.WP_K8S_VERSION }}
-          echo "k8sVersion=${k8sVersion:=${{ env.WP_K8S_VERSION }}}" >> $GITHUB_OUTPUT
-          # echo "::set-output name=k8sVersion::${k8sVersion:=${{ env.WP_K8S_VERSION }}}"
+          echo "k8sVersion=${k8sVersion:=${{ steps.latest_release_tag.outputs.latest_release_tag }}}" >> $GITHUB_OUTPUT
 
       - name: Clone workpath_k8s repository
         uses: actions/checkout@v3

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -57,7 +57,6 @@ on:
 
 
 env: 
-  WP_K8S_VERSION: latest
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:     


### PR DESCRIPTION
# Fixes [INFRA-578](https://workpathhq.atlassian.net/browse/INFRA-578)

## Summary
- referencing to latest in CD

## Details
Since we can optionally set the latest tag to new releases in the workpath_k8s repository and optionally provide a version with the WP_K8S_VERSION, we decided to use the latest tag now.
With this option we don't need to update the version to the latest version in this repository, each time a new release is created.

In order to reference the latest release we need to use the tag that is associated with latest.
This is done using the API of GitHub since the 'latest' tag is only available from there.
https://github.com/octokit/request-action is used to make the api call and steps were added to get the release tag, used in the deployments.

[Confluence Page](https://workpathhq.atlassian.net/wiki/spaces/OP/pages/6843760797/Release+management+of+workpath+k8s) about the release management.

