### PR TITLE
[INFRA-604] feat: automatic qa deletion

### DIFF
--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -3,8 +3,16 @@ name: Delete QA namespaces when redeployed
 on:
   workflow_call:
     inputs:
-      BRANCH_TAG:
+      GIT_SHORT_SHA:
         type: string
+        required: true
+      EKS_CLUSTER:
+        type: string
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
         required: true
 
 env:
@@ -17,8 +25,8 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Set EKS staging context for Kubectl
@@ -27,5 +35,4 @@ jobs:
           
       - name: Delete Namespaces with Git-branch label for PR
         run: |
-          export gitLabel=$(echo $GITHUB_HEAD_REF | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
-          kubectl delete namespaces -l git-branch=$gitLabel
+          kubectl delete namespaces -l git-branch=${{ inputs.GIT_SHORT_SHA }}

--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -35,4 +35,5 @@ jobs:
           
       - name: Delete Namespaces with Git-branch label for PR
         run: |
-          kubectl delete namespaces -l git-branch=${{ inputs.BRANCH_NAME }}
+          export gitLabel=$(echo $TAG | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
+          kubectl delete namespaces -l git-branch=$gitLabel

--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -3,7 +3,7 @@ name: Delete QA namespaces when redeployed
 on:
   workflow_call:
     inputs:
-      GIT_SHORT_SHA:
+      BRANCH_NAME:
         type: string
         required: true
       EKS_CLUSTER:
@@ -35,4 +35,4 @@ jobs:
           
       - name: Delete Namespaces with Git-branch label for PR
         run: |
-          kubectl delete namespaces -l git-branch=${{ inputs.GIT_SHORT_SHA }}
+          kubectl delete namespaces -l git-branch=${{ inputs.BRANCH_NAME }}

--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -1,0 +1,31 @@
+name: Delete QA namespaces when redeployed
+
+on:
+  workflow_call:
+    inputs:
+      BRANCH_TAG:
+        type: string
+        required: true
+
+env:
+  AWS_DEFAULT_REGION: eu-central-1
+
+jobs:
+  delete_namespaces_from_git-branch:
+    name: Delete QA namespaces with GitBranch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Set EKS staging context for Kubectl
+        run: |
+          aws eks --region ${{ env.AWS_DEFAULT_REGION }} update-kubeconfig --name wp-staging
+          
+      - name: Delete Namespaces with Git-branch label for PR
+        run: |
+          export gitLabel=$(echo $GITHUB_HEAD_REF | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
+          kubectl delete namespaces -l git-branch=$gitLabel

--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -35,5 +35,5 @@ jobs:
           
       - name: Delete Namespaces with Git-branch label for PR
         run: |
-          export gitLabel=$(echo $TAG | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
+          export gitLabel=$(echo ${{ inputs.BRANCH_NAME }} | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
           kubectl delete namespaces -l git-branch=$gitLabel

--- a/.github/workflows/delete-old-qa-envs.yml
+++ b/.github/workflows/delete-old-qa-envs.yml
@@ -37,3 +37,4 @@ jobs:
         run: |
           export gitLabel=$(echo ${{ inputs.BRANCH_NAME }} | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
           kubectl delete namespaces -l git-branch=$gitLabel
+          echo $gitLabel


### PR DESCRIPTION
# (Implements | Fixes ) [INFRA-604](https://workpathhq.atlassian.net/browse/INFRA-604)

<!--- The purpose of creating a good PR is to present your work to the reviewer, so that it's easy to understand the task and its implementation. This also serves as our own documentation for each line of code we touch ✨ -->

## Summary ⚡️

RFC for this PR: https://workpathhq.atlassian.net/wiki/spaces/OP/pages/6863716408/RFC-INFRA-002+GitOps+K8s+automatically+delete+qa+when+redeployed

Slack Poll: https://workpath.slack.com/archives/C01NDCL5EHL/p1671097553198979

Tldr: Multiple QA deployments from the same branch create many envs using up our resources, while only the last environment is used => We should delete the older envs when deploying a new QA environment.

This PR changes the behaviour of QA deployments:
The QA deployments will now delete any existing QA environments from the branch before deploying a new env. 
This will save us resources on our staging/qa cluster.

<!--- Brief description (can be a single sentence) of what this PR does. Basically a TLDR; -->
<!--- For example: This PR fixes the issue where... This PR implements... -->

## Details 🕵️‍♀️
This deletion uses the label we introduced for the automatic deletion of QA envs when closing a PR.
I added this step to run in parallel with the building of the image, to prevent slowing down the pipeline.
The actual deployment step will wait until the deletion is finished since otherwise the new deployment could be deleted.
<!-- This section is optional. If your pull request is straight forward and doesn't need a detailed explanation then you are free to remove this section. -->

[INFRA-604]: https://workpathhq.atlassian.net/browse/INFRA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ