### PR TITLE
[INFRA-440] refactor: Add Cache Credentials to Web Deploy

### DIFF
--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -46,8 +46,6 @@ on:
         required: true     
       RAILS_MASTER_KEY:
         required: true
-      REDIS_PASSWORD:
-        required: true
       DATABASE_PASSWORD:
         required: true
       GIT_ACCESS_TOKEN:
@@ -133,7 +131,6 @@ jobs:
           SMTP_USERNAME: ${{ inputs.SMTP_USERNAME }}
           AWS_SECRET_ACCESS_KEY_S3: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
 

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -46,6 +46,12 @@ on:
         required: true     
       RAILS_MASTER_KEY:
         required: true
+      SIDEKIQ_CACHE_PASSWORD:
+        required: true
+      FRAGMENT_CACHE_PASSWORD:
+        required: true
+      FLIPPER_CACHE_PASSWORD:
+        required: true
       DATABASE_PASSWORD:
         required: true
       GIT_ACCESS_TOKEN:
@@ -131,6 +137,9 @@ jobs:
           SMTP_USERNAME: ${{ inputs.SMTP_USERNAME }}
           AWS_SECRET_ACCESS_KEY_S3: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          SIDEKIQ_CACHE_PASSWORD: ${{ secrets.SIDEKIQ_CACHE_PASSWORD }}
+          FRAGMENT_CACHE_PASSWORD: ${{ secrets.FRAGMENT_CACHE_PASSWORD }}
+          FLIPPER_CACHE_PASSWORD: ${{ secrets.FLIPPER_CACHE_PASSWORD }}
           DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ WIP
 | AWS_SECRET_ACCESS_KEY | The secret access key for AWS |
 | AWS_SECRET_ACCESS_KEY_S3 | The secret access key for AWS S3 |
 | RAILS_MASTER_KEY | The Master Key for Rails |
+| SIDEKIQ_CACHE_PASSWORD_PASSWORD | The Password for Sidekiq Redis |
+| FRAGMENT_CACHE_PASSWORD | The Password for Fragment Cache Redis |
+| FLIPPER_CACHE_PASSWORD | The Password for Flipper Cache Redis |
 | DATABASE_PASSWORD | The Password for the database |
 | GIT_ACCESS_TOKEN | The Token for Github Access |
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ WIP
 | AWS_SECRET_ACCESS_KEY | The secret access key for AWS |
 | AWS_SECRET_ACCESS_KEY_S3 | The secret access key for AWS S3 |
 | RAILS_MASTER_KEY | The Master Key for Rails |
-| REDIS_PASSWORD | The Password for Redis |
 | DATABASE_PASSWORD | The Password for the database |
 | GIT_ACCESS_TOKEN | The Token for Github Access |
 


### PR DESCRIPTION
# Fixes [INFRA-440](https://workpathhq.atlassian.net/browse/INFRA_440)

## Summary

Adds Caching Credentials to `web-base-deploy` 



[INFRA-440]: https://workpathhq.atlassian.net/browse/INFRA-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ