### PR TITLE
fix: make fe deploy, not build reference the environment

### DIFF
--- a/.github/workflows/web-base-build-image.yml
+++ b/.github/workflows/web-base-build-image.yml
@@ -56,7 +56,6 @@ jobs:
   base_build_image:
     name: Build image
     runs-on: 8-cores
-    environment: ${{ inputs.WP_ENVIRONMENT }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -77,6 +77,7 @@ jobs:
   base_deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: ${{ inputs.WP_ENVIRONMENT }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:


### PR DESCRIPTION
## Summary
After rolling out https://github.com/WorkpathHQ/workpath_web/pull/2508, we noticed a change in our deployment automation behaviour: after deploying to staging, the workflow for the production deployment would no longer pause and wait for approval as documented in https://workpathhq.atlassian.net/wiki/spaces/ENG/pages/6840320414/GitHub+Actions+Production+Deployments - instead, it would start the deployment right away. 😨 

After some digging, I found out: 
1. this is a "Deployment protection rule", see [here](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules):
> Deployment protection rules require specific conditions to pass before a job referencing the environment can proceed. 

2. the most recent production workflow run wasn't listed as a deployment in https://github.com/WorkpathHQ/workpath_web/deployments .
3. in `web`, it's the `-base-build` job that has references the environment, whereas in `api`, it's in the `-base-deploy`. 

Flipping this should make the deployment protection work again. we can find out by merging this pr and rerunning the staging deployment in `web`. 
