### PR TITLE
[INFRA-696] Fix deployment information

### DIFF
--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -122,16 +122,16 @@ jobs:
           sudo mv ./kubectl /usr/local/bin/kubectl
           cd ${{ github.workspace }}/workpath_k8s/workpath_app
           ./envsubst-multi.sh && source ./envsubst-multi.sh
-          echo "$(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }}) env will be reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.hooli.$WP_DOMAIN"
           kubectl apply -k overlays/${{ inputs.WP_ENVIRONMENT }}
           if [ ${{ inputs.WP_ENVIRONMENT }} == qa ]; then
             kubectl rollout status deploy workpath-api -n $WP_SUBDOMAIN --timeout=400s
+            echo "Successful deployment on $(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }}), reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.connect.$WP_DOMAIN"
           else
             kubectl -n workpath-${{ inputs.WP_ENVIRONMENT }} rollout restart deployment workpath-api workpath-cronjobs workpath-sidekiq workpath-sidekiq-graph workpath-sidekiq-integrations
             kubectl -n workpath-${{ inputs.WP_ENVIRONMENT }} rollout status deploy workpath-api --timeout=900s
+            echo "Successful deployment on $(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }})"
           fi
 
-          echo "Succesful Deploy on $(tr '[:lower:]' '[:upper:]' <<< {{ inputs.WP_ENVIRONMENT }}), reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.connect.$WP_DOMAIN, *.$WP_DOMAIN"
 
         # Workaround for setting inputs as environmental variables (https://github.com/actions/runner/issues/665#issuecomment-699481628)
         env:

--- a/.github/workflows/prologue.yml
+++ b/.github/workflows/prologue.yml
@@ -58,7 +58,7 @@ jobs:
           GIT_SHORTENED_BRANCH=$(echo "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
           GIT_SHORT_SHA=$(echo $GIT_SHA | cut -c1-7)
           WP_SUBDOMAIN="$GIT_SHORTENED_BRANCH-$GIT_SHORT_SHA"
-          GIT_COMMIT_AUTHOR_SUBJECT=$(git show -s --format='%an %s')
+          GIT_COMMIT_AUTHOR_SUBJECT=$(git show -s --format='%an %s' | sed "s/'//g")
           echo "git_project_name=$GIT_PROJECT_NAME" >> $GITHUB_OUTPUT
           echo "git_branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "git_shortened_branch=$GIT_SHORTENED_BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -126,17 +126,18 @@ jobs:
           sudo mv ./kubectl /usr/local/bin/kubectl
           cd ${{ github.workspace }}/workpath_k8s/workpath_app
           ./envsubst-multi.sh && source ./envsubst-multi.sh
-          echo "$(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }}) env will be reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.hooli.$WP_DOMAIN"
           if [ ${{ inputs.WP_ENVIRONMENT }} == qa ]; then
             kubectl apply -k overlays/${{ inputs.WP_ENVIRONMENT }}
             kubectl rollout status deploy workpath-web -n $WP_SUBDOMAIN --timeout=0s
             kubectl rollout status deploy workpath-api -n $WP_SUBDOMAIN --timeout=300s
+            echo "Successful deployment on $(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }}), reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.connect.$WP_DOMAIN"
           else
             kubectl apply -k overlays/${{ inputs.WP_ENVIRONMENT }} --selector "app in (workpath-ns, workpath-web)"
             kubectl -n workpath-${{ inputs.WP_ENVIRONMENT }} rollout restart deployment workpath-web
             kubectl -n workpath-${{ inputs.WP_ENVIRONMENT }} rollout status deploy workpath-web --timeout=0s
+            echo "Successful deployment on $(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }})"
           fi
-          echo "Succesful Deploy on $(tr '[:lower:]' '[:upper:]' <<< {{ inputs.WP_ENVIRONMENT }}), reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.connect.$WP_DOMAIN, *.$WP_DOMAIN"
+          
 
         # Workaround for setting inputs as environmental variables (https://github.com/actions/runner/issues/665#issuecomment-699481628)
         env:


### PR DESCRIPTION
# Fixes [INFRA-696](https://workpathhq.atlassian.net/browse/INFRA-696) and [INFRA-697](https://workpathhq.atlassian.net/browse/INFRA-697)

## Summary
- Deployments show QA information regardless of whether it's actually a QA deployment or not.
- Show QA URLs only if it's a QA deploy, otherwise just show that the deployment was successful for the current environment (staging or production).
- Removes quotes from commit messages as they break Slack notifications.



[INFRA-696]: https://workpathhq.atlassian.net/browse/INFRA-696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[INFRA-697]: https://workpathhq.atlassian.net/browse/INFRA-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ