### PR TITLE
Run backend image build on 8-cores

### DIFF
--- a/.github/workflows/api-base-build-image.yml
+++ b/.github/workflows/api-base-build-image.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   base_build_image:
     name: Build image
-    runs-on: ubuntu-latest
+    runs-on: 8-cores
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Tested this, and it speeds up backend image build by nearly 2x!