### PR TITLE
[INFRA-744] chore: Add Dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"


### PR DESCRIPTION
# Fixes [INFRA-744](https://workpathhq.atlassian.net/browse/INFRA-744)

## Details
- Adding Dependabot for Github Actions to automatically address deprecations in some of the workflows.
- Reference [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

![Screenshot 2024-05-07 at 09 24 51](https://github.com/WorkpathHQ/workpath_api/assets/93599791/9a5225ed-ac6a-4972-a8db-f60b57f71f7d)


[INFRA-744]: https://workpathhq.atlassian.net/browse/INFRA-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ