### PR TITLE
[INFRA-848] Add Bedrock AWS access key

### DIFF
--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -67,9 +67,9 @@ on:
       OPEN_AI_AZURE_URI:
         required: true
       AWS_ACCESS_KEY_ID_BEDROCK:
-        required: true
+        required: false
       AWS_SECRET_ACCESS_KEY_BEDROCK:
-        required: true
+        required: false
 
 
 env:

--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -66,6 +66,10 @@ on:
         required: true
       OPEN_AI_AZURE_URI:
         required: true
+      AWS_ACCESS_KEY_ID_BEDROCK:
+        required: true
+      AWS_SECRET_ACCESS_KEY_BEDROCK:
+        required: true
 
 
 env:
@@ -159,3 +163,5 @@ jobs:
           TABLEAU_ADMIN_PASSWORD: ${{ secrets.TABLEAU_ADMIN_PASSWORD }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
           OPEN_AI_AZURE_URI: ${{ secrets.OPEN_AI_AZURE_URI }}
+          AWS_ACCESS_KEY_ID_BEDROCK: ${{ secrets.AWS_ACCESS_KEY_ID_BEDROCK }}
+          AWS_SECRET_ACCESS_KEY_BEDROCK: ${{ secrets.AWS_SECRET_ACCESS_KEY_BEDROCK }}


### PR DESCRIPTION
# Fixes [INFRA-848](https://workpathhq.atlassian.net/browse/INFRA-848)

## Summary
- Add AWS access key for Bedrock IAM user on staging and QA.
- Set required to false as they aren't needed on production yet.
- Terraform PR https://github.com/WorkpathHQ/workpath_tf/pull/182


[INFRA-848]: https://workpathhq.atlassian.net/browse/INFRA-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ