### PR TITLE
[INFRA-850] Bump workpath-api status timeout value

### DIFF
--- a/.github/workflows/api-base-deploy.yml
+++ b/.github/workflows/api-base-deploy.yml
@@ -131,7 +131,7 @@ jobs:
           ./envsubst-multi.sh && source ./envsubst-multi.sh
           kubectl apply -k overlays/${{ inputs.WP_ENVIRONMENT }}
           if [ ${{ inputs.WP_ENVIRONMENT }} == qa ]; then
-            kubectl rollout status deploy workpath-api -n $WP_SUBDOMAIN --timeout=400s
+            kubectl rollout status deploy workpath-api -n $WP_SUBDOMAIN --timeout=900s
             echo "Successful deployment on $(tr '[:lower:]' '[:upper:]' <<< ${{ inputs.WP_ENVIRONMENT }}), reachable via $WP_SUBDOMAIN.admin.$WP_DOMAIN, $WP_SUBDOMAIN.api.$WP_DOMAIN, $WP_SUBDOMAIN.connect.$WP_DOMAIN"
           else
             kubectl -n workpath-${{ inputs.WP_ENVIRONMENT }} rollout restart deployment workpath-api workpath-cronjobs workpath-sidekiq workpath-sidekiq-graph workpath-sidekiq-integrations


### PR DESCRIPTION
# Fixes [INFRA-850](https://workpathhq.atlassian.net/browse/INFRA-850)

## Summary
- QA deployments are timing out because the database takes longer to seed than it used to.
- Bumped timeout value to compensate for this.




[INFRA-850]: https://workpathhq.atlassian.net/browse/INFRA-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ