### PR TITLE
[PL-3514] Add Posthog host and key to build and deploy

### DIFF
--- a/.github/workflows/web-base-build-image.yml
+++ b/.github/workflows/web-base-build-image.yml
@@ -47,6 +47,8 @@ on:
         required: true
       CYPRESS_SESSION_AUTH_TOKEN:
         required: true
+      POSTHOG_KEY:
+        required: false
 
 env:
   AWS_DEFAULT_REGION: eu-central-1


### PR DESCRIPTION
# Fixes [PL-3514](https://workpathhq.atlassian.net/browse/PL-3514)

## Summary
- Posthog requires env vars at build time and deploy.




[PL-3514]: https://workpathhq.atlassian.net/browse/PL-3514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ