### PR TITLE
[INFRA-889] fix: Add missing input

### DIFF
--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -42,7 +42,9 @@ on:
       POSTHOG_HOST:
         type: string
         required: false
-
+      AGENT_BASE:
+        type: string
+        required: false
 
     secrets:
       AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
# Fixes [INFRA-889](https://workpathhq.atlassian.net/browse/INFRA-889)

## Summary
- `AGENT_BASE` is used by the production deployment (not build). It is needed here also.



[INFRA-889]: https://workpathhq.atlassian.net/browse/INFRA-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ