### PR TITLE
[INFRA-893] Remove Cypress from builds

### DIFF
--- a/.github/workflows/prologue.yml
+++ b/.github/workflows/prologue.yml
@@ -55,7 +55,7 @@ jobs:
             git checkout $GIT_SHA
           fi
           GIT_BRANCH=$(echo ${GIT_REFERENCE#refs/heads/})
-          GIT_SHORTENED_BRANCH=$(echo "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
+          GIT_SHORTENED_BRANCH=$(echo "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/-*$//')
           GIT_SHORT_SHA=$(echo $GIT_SHA | cut -c1-7)
           WP_SUBDOMAIN="$GIT_SHORTENED_BRANCH-$GIT_SHORT_SHA"
           GIT_COMMIT_AUTHOR_SUBJECT=$(git show -s --format='%an %s' | sed "s/'//g")

--- a/.github/workflows/web-base-build-image.yml
+++ b/.github/workflows/web-base-build-image.yml
@@ -12,22 +12,10 @@ on:
       API_BASE:
         type: string
         required: true
-      GA_TRACKING_ID:
-        type: string
-        required: true
       SENTRY_ENVIRONMENT:
         type: string
         required: true
       SENTRY_URL:
-        type: string
-        required: true
-      CYPRESS_USER_AUTH_USER:
-        type: string
-        required: true
-      CYPRESS_BASE_URL:
-        type: string
-        required: true
-      CYPRESS_WORKPATH_ACCOUNT:
         type: string
         required: true
       WP_ENVIRONMENT:
@@ -48,10 +36,6 @@ on:
       FONTAWESOME_TOKEN:
         required: true
       BAUKASTEN_TOKEN:
-        required: true
-      CYPRESS_USER_AUTH_PASS:
-        required: true
-      CYPRESS_SESSION_AUTH_TOKEN:
         required: true
       POSTHOG_KEY:
         required: false
@@ -80,5 +64,5 @@ jobs:
 
       - name: Build, tag, and push image to AWS ECR
         run: |
-          docker build --build-arg AGENT_BASE=${{ inputs.AGENT_BASE }} --build-arg FONTAWESOME_TOKEN=${{ secrets.FONTAWESOME_TOKEN }} --build-arg API_BASE=${{ inputs.API_BASE }} --build-arg BAUKASTEN_TOKEN=${{ secrets.BAUKASTEN_TOKEN }} --build-arg SENTRY_URL=${{ inputs.SENTRY_URL }} --build-arg GA_TRACKING_ID=${{ inputs.GA_TRACKING_ID }} --build-arg SENTRY_ENVIRONMENT=${{ inputs.SENTRY_ENVIRONMENT }} --build-arg CYPRESS_USER_AUTH_USER=${{ inputs.CYPRESS_USER_AUTH_USER }} --build-arg CYPRESS_USER_AUTH_PASS=${{ secrets.CYPRESS_USER_AUTH_PASS }} --build-arg CYPRESS_BASE_URL=${{ inputs.CYPRESS_BASE_URL }} --build-arg CYPRESS_WORKPATH_ACCOUNT=${{ inputs.CYPRESS_WORKPATH_ACCOUNT }} --build-arg CYPRESS_SESSION_AUTH_TOKEN=${{ secrets.CYPRESS_SESSION_AUTH_TOKEN }} --build-arg POSTHOG_HOST=${{ inputs.POSTHOG_HOST }} --build-arg POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} --tag ${{ env.ECR_REGISTRY }}/${{ inputs.ECR_REPOSITORY }}:${{ inputs.IMAGE_TAG }} .
+          docker build --build-arg AGENT_BASE=${{ inputs.AGENT_BASE }} --build-arg FONTAWESOME_TOKEN=${{ secrets.FONTAWESOME_TOKEN }} --build-arg API_BASE=${{ inputs.API_BASE }} --build-arg BAUKASTEN_TOKEN=${{ secrets.BAUKASTEN_TOKEN }} --build-arg SENTRY_URL=${{ inputs.SENTRY_URL }} --build-arg SENTRY_ENVIRONMENT=${{ inputs.SENTRY_ENVIRONMENT }} --build-arg POSTHOG_HOST=${{ inputs.POSTHOG_HOST }} --build-arg POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} --tag ${{ env.ECR_REGISTRY }}/${{ inputs.ECR_REPOSITORY }}:${{ inputs.IMAGE_TAG }} .
           docker push ${{ env.ECR_REGISTRY }}/${{ inputs.ECR_REPOSITORY }}:${{ inputs.IMAGE_TAG }}

--- a/.github/workflows/web-base-deploy.yml
+++ b/.github/workflows/web-base-deploy.yml
@@ -30,9 +30,6 @@ on:
       WP_K8S_VERSION:
         type: string
         required: false
-      GA_TRACKING_ID:
-        type: string
-        required: true
       SENTRY_ENVIRONMENT:
         type: string
         required: true
@@ -161,7 +158,6 @@ jobs:
           AWS_ACCESS_KEY_ID_S3: ${{ secrets.AWS_ACCESS_KEY_ID_S3 }}
           WP_DOMAIN: ${{ inputs.WP_DOMAIN }}
           SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
-          GA_TRACKING_ID: ${{ inputs.GA_TRACKING_ID }}
           SENTRY_ENVIRONMENT: ${{ inputs.SENTRY_ENVIRONMENT }}
           SENTRY_URL: ${{ inputs.SENTRY_URL }}
           AWS_SECRET_ACCESS_KEY_S3: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3 }}


### PR DESCRIPTION
# Fixes [INFRA-893](https://workpathhq.atlassian.net/browse/INFRA-893)

## Summary ⚡️
- In [this](https://github.com/WorkpathHQ/workpath_web/pull/3533) PR, Cypress was completely removed. We still have references to Cypress in our builds that also need to be removed.
- Also removed `GA_TRACKING_ID` as it is no longer used.
- Tested in QA env https://remove-cypress-ref.hooli.workpath.dev/
- PR for frontend is [here](https://github.com/WorkpathHQ/workpath_web/pull/3595)

[INFRA-893]: https://workpathhq.atlassian.net/browse/INFRA-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ