### PR TITLE
[PL-3760] remove BAUKASTEN_TOKEN from codebase

### DIFF
--- a/.github/workflows/prologue.yml
+++ b/.github/workflows/prologue.yml
@@ -55,7 +55,7 @@ jobs:
             git checkout $GIT_SHA
           fi
           GIT_BRANCH=$(echo ${GIT_REFERENCE#refs/heads/})
-          GIT_SHORTENED_BRANCH=$(echo "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/\(.*\)-/\1/')
+          GIT_SHORTENED_BRANCH=$(echo "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed "s/\//-/g" | sed "s/\_/-/g" | sed "s/\./-/g" | cut -c1-54 | sed 's/-*$//')
           GIT_SHORT_SHA=$(echo $GIT_SHA | cut -c1-7)
           WP_SUBDOMAIN="$GIT_SHORTENED_BRANCH-$GIT_SHORT_SHA"
           GIT_COMMIT_AUTHOR_SUBJECT=$(git show -s --format='%an %s' | sed "s/'//g")

--- a/.github/workflows/web-base-build-image.yml
+++ b/.github/workflows/web-base-build-image.yml
@@ -35,8 +35,6 @@ on:
         required: true
       FONTAWESOME_TOKEN:
         required: true
-      BAUKASTEN_TOKEN:
-        required: true
       POSTHOG_KEY:
         required: false
 
@@ -80,7 +78,6 @@ jobs:
           build-args: |
             FONTAWESOME_TOKEN=${{ secrets.FONTAWESOME_TOKEN }}
             API_BASE=${{ inputs.API_BASE }}
-            BAUKASTEN_TOKEN=${{ secrets.BAUKASTEN_TOKEN }}
             POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
             SENTRY_URL=${{ inputs.SENTRY_URL }}
             SENTRY_ENVIRONMENT=${{ inputs.SENTRY_ENVIRONMENT }}


### PR DESCRIPTION
# Fixes [PL-3760](https://workpathhq.atlassian.net/browse/PL-3760)

## Summary
- In [this](https://github.com/WorkpathHQ/workpath_web/pull/3626) PR we remove Baukasten so we also need to remove it from the web build workflow.




[PL-3760]: https://workpathhq.atlassian.net/browse/PL-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ